### PR TITLE
Names instead of IDs on cover

### DIFF
--- a/qml/notificationCount.js
+++ b/qml/notificationCount.js
@@ -15,7 +15,7 @@ function _calculateRoomName(summaryData, members) {
         if (sortedMembers.length > 1) {
             const lastMember = sortedMembers[sortedMembers.length - 1];
             const firstMembers = sortedMembers.slice(0, sortedMembers.length - 1);
-            return firstMembers.map(m => m.displayName).join(", ") + " and " + lastMember.displayName;
+            return firstMembers.map(m => m.displayName).join(", ") + " , and " + lastMember.displayName;
         } else {
             const otherMember = sortedMembers[0];
             if (otherMember) {
@@ -25,7 +25,7 @@ function _calculateRoomName(summaryData, members) {
             }
         }
     } else if (sortedMembers.length < countWithoutMe) {
-        return sortedMembers.map(m => m.displayName).join(", ") + ` and ${countWithoutMe} others`;
+        return sortedMembers.map(m => m.displayName).join(", ") + ` , and ${countWithoutMe} others`;
     } else {
         // Empty Room
         return null;

--- a/qml/notificationCount.js
+++ b/qml/notificationCount.js
@@ -5,6 +5,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+/*
+ * Access an object store.
+ *
+ * Arguments:
+ *   db: opened indexedDB
+ *   name: str
+ *   onError: function(request: request, event: str)
+ *   onSuccess: function(request: request, event: str)
+ */
+function _accessObjectStore(db, name, onError, onSuccess) {
+    var transaction = db.transaction(name, "readonly", "relaxed");
+    var storeNames = Array.from(transaction.objectStoreNames);
+
+    if (storeNames.indexOf(name) === -1) {
+        onError("object store '" + name + "' not found");
+    }
+
+    var objectStore = transaction.objectStore(name);
+
+    var request = objectStore.getAll();
+
+    request.onerror = function(event) { onError(request, event); }
+    request.onsuccess = function(event) { onSuccess(request, event); }
+}
+
 function getCurrentSession() {
     var matches = window.location.hash.match(/session\/(\d+)/);
     if (matches && matches.length > 1) {
@@ -24,36 +49,28 @@ function refreshSession() {
     result.onsuccess = function(event) {
         var db = event.target.result;
 
-        var transaction = db.transaction("roomSummary", "readonly", "relaxed");
-        var storeNames = Array.from(transaction.objectStoreNames);
-        if (storeNames.indexOf("roomSummary") === -1) return;
+        _accessObjectStore(db, "roomSummary", function(request, event){
+            console.error(event);
+        }, function(request, event) {
+            var notificationCount = request.result.reduce((sum, item) => sum + item.notificationCount, 0);
 
-        var objectStore = transaction.objectStore("roomSummary");
+            // Most recent bunch of discussions with unread
+            let mostRecentCount = 20;
+            let coverPreview = request.result.filter(item => !!item.notificationCount)
+                    .sort((x,y) => x.lastMessageTimestamp - y.lastMessageTimestamp)
+                    .slice(-mostRecentCount).map(item => ({
+                        name: item.name || item.heroes[0],
+                        count: item.notificationCount,
+                    })).reverse();
 
-        var request = objectStore.getAll();
-        request.onerror = function(event) {
-          console.error(event);
-        };
-        request.onsuccess = function(event) {
-          var notificationCount = request.result.reduce((sum, item) => sum + item.notificationCount, 0);
-
-          // Most recent bunch of discussions with unread
-          let mostRecentCount = 20;
-          let coverPreview = request.result.filter(item => !!item.notificationCount)
-                .sort((x,y) => x.lastMessageTimestamp - y.lastMessageTimestamp)
-                .slice(-mostRecentCount).map(item => ({
-                    name: item.name || item.heroes[0],
-                    count: item.notificationCount,
-                })).reverse();
-
-          var customEvent = new CustomEvent("framescript:notificationCount", {
-              detail: {
-                  count: notificationCount,
-                  coverPreview: coverPreview,
-              }
-          });
-          document.dispatchEvent(customEvent);
-        };
+            var customEvent = new CustomEvent("framescript:notificationCount", {
+                detail: {
+                    count: notificationCount,
+                    coverPreview: coverPreview,
+                }
+            });
+            document.dispatchEvent(customEvent);
+        });
     }
 }
 


### PR DESCRIPTION
Previously: if a room had no name, the first member's user ID was used as handle on the cover, e.g. `@x:matrix.org`.
Now: unnamed rooms are shown as a list of their member's display names, e.g. `Joe, Jane, and Jim`.

The code is annoyingly complex and probably not very efficient, but I didn't find a way around it. It has to access two databases asynchronously and merge the results...

Fixes #52.